### PR TITLE
Fixed wrong Fibonacci Tester

### DIFF
--- a/code/exercises/src/test/java/com/nbicocchi/exercises/arrays/FibonacciTest.java
+++ b/code/exercises/src/test/java/com/nbicocchi/exercises/arrays/FibonacciTest.java
@@ -7,8 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 public class FibonacciTest {
     @Test
     public void fibonacci() {
-        assertArrayEquals(new long[]{1}, Fibonacci.fibonacci(1));
-        assertArrayEquals(new long[]{1, 1}, Fibonacci.fibonacci(2));
-        assertArrayEquals(new long[]{1, 1, 2, 3, 5}, Fibonacci.fibonacci(5));
+        assertArrayEquals(new long[]{0}, Fibonacci.fibonacci(1));
+        assertArrayEquals(new long[]{0, 1}, Fibonacci.fibonacci(2));
+        assertArrayEquals(new long[]{0, 1, 1, 2, 3}, Fibonacci.fibonacci(5));
     }
 }


### PR DESCRIPTION
Fibonacci series starts with 0, but the testing method was working with 1 as the starting number of the series, thus causing issues with the tests.