### PR TITLE
Changed AbstractPoly#equals

### DIFF
--- a/code/exercises/src/main/java/com/nbicocchi/exercises/oop/polynomials/AbstractPoly.java
+++ b/code/exercises/src/main/java/com/nbicocchi/exercises/oop/polynomials/AbstractPoly.java
@@ -24,9 +24,10 @@ public abstract class AbstractPoly implements Poly {
 
     @Override
     public boolean equals(Object o) {
-        if (o == null) {
-            return false;
-        }
+        if(this == o) return true;
+
+        // This check will still fail if
+        // the object o is null
         if (!(o instanceof Poly p)) {
             return false;
         }

--- a/code/exercises/src/test/java/com/nbicocchi/exercises/oop/polynomials/PolyTestBase.java
+++ b/code/exercises/src/test/java/com/nbicocchi/exercises/oop/polynomials/PolyTestBase.java
@@ -17,6 +17,7 @@ abstract class PolyTestBase {
         assertEquals(p, pc);
         assertNotEquals(p, pb);
         assertNotEquals(p, pd);
+        assertNotEquals(p, null);
     }
 
     @Test


### PR DESCRIPTION
The instance of check works also if the object is null, for this reason the null check can be removed. I added a test to confirm that.
I also added a check that helps to avoid further calculations when a Poly is compared to itself.