### PR TITLE
Tested negative Operational fee, more IBANs

### DIFF
--- a/code/exercises/src/test/java/com/nbicocchi/exercises/oop/bankaccount/AbstractBankAccountTest.java
+++ b/code/exercises/src/test/java/com/nbicocchi/exercises/oop/bankaccount/AbstractBankAccountTest.java
@@ -1,0 +1,18 @@
+package com.nbicocchi.exercises.oop.bankaccount;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AbstractBankAccountTest {
+    ConcreteBankAccount bankAccount;
+    @BeforeEach
+    void init() {
+        bankAccount = new ConcreteBankAccount("IT0000012345", 1000, 2.0, 0.0);
+    }
+    @Test
+    void checkInterestRate() {
+        assertThrows(IllegalArgumentException.class, () -> bankAccount.setOperationFee(-2.0));
+    }
+}

--- a/code/exercises/src/test/java/com/nbicocchi/exercises/oop/bankaccount/BankAccountEasyTest.java
+++ b/code/exercises/src/test/java/com/nbicocchi/exercises/oop/bankaccount/BankAccountEasyTest.java
@@ -19,6 +19,8 @@ class BankAccountEasyTest {
         assertThrows(IllegalArgumentException.class, () -> new BankAccountEasy("It001234", 0.0));
         assertThrows(IllegalArgumentException.class, () -> new BankAccountEasy("It001234", 0.0));
         assertThrows(IllegalArgumentException.class, () -> new BankAccountEasy("it001234", 0.0));
+        assertThrows(IllegalArgumentException.class, () -> new BankAccountEasy("i0001234", 0.0));
+        assertThrows(IllegalArgumentException.class, () -> new BankAccountEasy("IT123456789012345678901234567890123", 0.0));
         assertDoesNotThrow(() -> new BankAccountEasy("IT001234", 0.0));
     }
 

--- a/code/exercises/src/test/java/com/nbicocchi/exercises/oop/bankaccount/ConcreteBankAccount.java
+++ b/code/exercises/src/test/java/com/nbicocchi/exercises/oop/bankaccount/ConcreteBankAccount.java
@@ -1,0 +1,16 @@
+package com.nbicocchi.exercises.oop.bankaccount;
+
+public class ConcreteBankAccount extends AbstractBankAccount{
+
+    /**
+     * Construct a new BankAccount
+     *
+     * @param IBAN         the IBAN of the account
+     * @param balance      the initial balance of the account
+     * @param operationFee the fee to be applied to deposit and withdraw operations
+     * @param interestRate the interest rate to be applied
+     */
+    protected ConcreteBankAccount(String IBAN, double balance, double operationFee, double interestRate) {
+        super(IBAN, balance, operationFee, interestRate);
+    }
+}


### PR DESCRIPTION
Added ConcreteBankAccount to test a negative operation fee that wasn't tested before but an important part of the exercise as stated in the README. Added more IBAN controls such as lenght and country code.