### PR TITLE
Update MeasureTest.java

### DIFF
--- a/code/exercises/src/test/java/com/nbicocchi/exercises/generics/MeasureTest.java
+++ b/code/exercises/src/test/java/com/nbicocchi/exercises/generics/MeasureTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class MeasureTest {
 
     @Test
-    void max() {
+    void measure() {
         Measure.Measurer<String> measurer = new Measure.Measurer<>() {
             @Override
             public double measure(String item) {


### PR DESCRIPTION
Changed test function name from "max" to "measure". I reckon it's more straightforward and less misleading considering that in the "Measure" class we already have a function called "max".