### PR TITLE
Update NoYYZTest.java

### DIFF
--- a/code/exercises/src/test/java/com/nbicocchi/exercises/functional/NoYYZTest.java
+++ b/code/exercises/src/test/java/com/nbicocchi/exercises/functional/NoYYZTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class NoYYZTest {
     @Test
-    void noYY() {
+    void noYYZ() {
         assertEquals(List.of("ay", "by", "cy"), NoYYZ.noYYZ(List.of("a", "b", "c")));
         assertEquals(List.of("ay", "by"), NoYYZ.noYYZ(List.of("a", "b", "cy")));
         assertEquals(List.of("xxy", "yay", "zzy"), NoYYZ.noYYZ(List.of("xx", "ya", "zz")));


### PR DESCRIPTION
Changed test function name from "noYY" to "noYYZ" because the first one refers to the previous exercise.