### PR TITLE
Update README.md of the functional package

### DIFF
--- a/code/exercises/src/main/java/com/nbicocchi/exercises/functional/README.md
+++ b/code/exercises/src/main/java/com/nbicocchi/exercises/functional/README.md
@@ -286,10 +286,10 @@ public static class Account {
 ```
 
 Write a method for: 
-(a) filtering all the accounts whose duePayment is expired, 
-(b) apply interests (amount += amount * interestRate),
-(c) sort them based their on amount,
-(d) return a List of the filtered accounts.
+* (a) filtering all the accounts whose duePayment is expired, 
+* (b) apply interests (amount += amount * interestRate),
+* (c) sort them based their on amount (in decremental order),
+* (d) return a List of the filtered accounts.
 
 The method has the following prototype:
 


### PR DESCRIPTION
added bulletted list for specifics of bankaccount exercise in "functional" package, also specified the requirement of having the list sorted in decremental order. In both the presented test and solution it does so, but in the exercise request is never explicitly told. Since someone may just copy and paste the premade test, I thought that having that part specified in the README could avoid confusion on why the test assertions are failing. 