### PR TITLE
Fix minor mistake

### DIFF
--- a/slides/E2.1 - Java Basics.md
+++ b/slides/E2.1 - Java Basics.md
@@ -90,7 +90,7 @@ public class HelloWorld {
 Integral literals consist of digit sequences and are broken down into these subtypes:
 
 * **Decimal Integer**: Decimal integers use a base ten and digits ranging from 0 to 9. They can have a negative (-) or a positive (+), but non-digit characters or commas aren’t allowed between characters. Example: int d = 2022, +42, -68.
-* **Octal Integer**: Octal integers use a base eight and digits ranging from 0 to 7. Octal integers always begin with a "0" Example: int o = 007, 0295.
+* **Octal Integer**: Octal integers use a base eight and digits ranging from 0 to 7. Octal integers always begin with a "0" Example: int o = 007, 0275.
 * **Hexadecimal**: Hexadecimal integers work with a base 16 and use digits from 0 to 9 and the characters of A through F. The characters are case-sensitive and represent a 10 to 15 numerical range. Example: int e = 0xFF, 0x9A.
 * **Binary Integer**: Binary integers uses a base two, consisting of the digits "0" and "1". The prefix "0b" represents the Binary system. Example: int b = 0b11011.
 


### PR DESCRIPTION
changed example of octal representation which include a "9" as a digit.