### PR TITLE
FIx EqualIsNot.java

### DIFF
--- a/code/exercises/src/main/java/com/nbicocchi/exercises/strings/EqualIsNot.java
+++ b/code/exercises/src/main/java/com/nbicocchi/exercises/strings/EqualIsNot.java
@@ -12,11 +12,13 @@ public class EqualIsNot {
             return true;
         }
 
-        int indexIs = 0, indexNot = 0;
+        int indexIs = string.indexOf("is");
+        int indexNot = string.indexOf("not");
         while (indexIs != -1 && indexNot != -1) {
-            indexIs = string.indexOf("is", indexIs + 1);
-            indexNot = string.indexOf("not", indexNot + 1);
+            indexIs = string.indexOf("is", indexIs + 2);
+            indexNot = string.indexOf("not", indexNot + 3);
         }
         return indexIs == indexNot;
     }
+
 }

--- a/code/exercises/src/main/java/com/nbicocchi/exercises/strings/README.md
+++ b/code/exercises/src/main/java/com/nbicocchi/exercises/strings/README.md
@@ -219,6 +219,7 @@ where:
 
 Examples:
 
+* equalIsNot("is not") → true
 * equalIsNot("This is not") → false
 * equalIsNot("This is notnot") → true
 * equalIsNot("noisxxnotyynotxisi") → true

--- a/code/exercises/src/test/java/com/nbicocchi/exercises/strings/EqualIsNotTest.java
+++ b/code/exercises/src/test/java/com/nbicocchi/exercises/strings/EqualIsNotTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class EqualIsNotTest {
     @Test
     void equalIsNot() {
+        assertTrue(EqualIsNot.equalIsNot("is not"));
         assertFalse(EqualIsNot.equalIsNot("This is not"));
         assertTrue(EqualIsNot.equalIsNot("This is notnot"));
         assertTrue(EqualIsNot.equalIsNot("noisxxnotyynotxisi"));


### PR DESCRIPTION
In the previous version, the case with with strings = "is not" was returning false, but I believe it should return true.
All "is"/ "not" that start at the beginning of the string (index 0) were not being counted.