### PR TITLE
Fixed RemoveFirstTwoCharsIf

### DIFF
--- a/code/exercises/src/main/java/com/nbicocchi/exercises/strings/README.md
+++ b/code/exercises/src/main/java/com/nbicocchi/exercises/strings/README.md
@@ -70,7 +70,7 @@ where:
 Examples:
 
 * removeFirstTwoCharsIf("Hello World!") → "Hello World!"
-* removeFirstTwoCharsIf("Good World!") → "od World!"
+* removeFirstTwoCharsIf("The pen is on the table") → "e pen is on the table"
 * removeFirstTwoCharsIf("Ho") → "H"
 * removeFirstTwoCharsIf("Ne") → "e"
 * removeFirstTwoCharsIf("Y") → ""

--- a/code/exercises/src/main/java/com/nbicocchi/exercises/strings/RemoveFirstTwoCharsIf.java
+++ b/code/exercises/src/main/java/com/nbicocchi/exercises/strings/RemoveFirstTwoCharsIf.java
@@ -29,11 +29,18 @@ public class RemoveFirstTwoCharsIf {
 
     public static String removeFirstTwoCharsIfStringBuilder(String string) {
         StringBuilder sb = new StringBuilder(string);
+        int deletedH=0;
         if (!string.isEmpty() && string.charAt(0) != 'H') {
             sb.deleteCharAt(0);
+            deletedH=1;
         }
         if (string.length() > 1 && string.charAt(1) != 'e') {
-            sb.deleteCharAt(1);
+            if(deletedH==0){
+                sb.deleteCharAt(1);
+            }
+            else{
+                sb.deleteCharAt(0);
+            }
         }
         return sb.toString();
     }

--- a/code/exercises/src/test/java/com/nbicocchi/exercises/strings/RemoveFirstTwoCharsIfTest.java
+++ b/code/exercises/src/test/java/com/nbicocchi/exercises/strings/RemoveFirstTwoCharsIfTest.java
@@ -19,6 +19,7 @@ public class RemoveFirstTwoCharsIfTest {
     public void removeFirstTwoCharsIfStringBuilder() {
         assertEquals("Hello World!", RemoveFirstTwoCharsIf.removeFirstTwoCharsIfStringBuilder("Hello World!"));
         assertEquals("od World!", RemoveFirstTwoCharsIf.removeFirstTwoCharsIfStringBuilder("Good World!"));
+        assertEquals("e pen is on the table", RemoveFirstTwoCharsIf.removeFirstTwoCharsIfStringBuilder("The pen is on the table"));
         assertEquals("H", RemoveFirstTwoCharsIf.removeFirstTwoCharsIfStringBuilder("Ho"));
         assertEquals("e", RemoveFirstTwoCharsIf.removeFirstTwoCharsIfStringBuilder("Ne"));
         assertEquals("", RemoveFirstTwoCharsIf.removeFirstTwoCharsIfStringBuilder("Y"));


### PR DESCRIPTION
I think there was a mistake in the previous version. If both the first two letters were to be deleted, the first and third letters were actually deleted, rather than the first and second. In the test it did not give an error because in Good the second and third letters are the same.