### PR TITLE
Tests Arrays update

### DIFF
--- a/code/exercises/src/test/java/com/nbicocchi/exercises/arrays/DeepCopyTest.java
+++ b/code/exercises/src/test/java/com/nbicocchi/exercises/arrays/DeepCopyTest.java
@@ -12,5 +12,13 @@ class DeepCopyTest {
         int[][] deepCopy = DeepCopy.deepCopy(matrix);
         assertTrue(deepCopy[0] != matrix[0]);
         assertTrue(deepCopy[1] != matrix[1]);
+
+        int[][] matrix1 = {{4, 5, 3}, {2, 1, 6}, {7, 0}, {1, 5, 2, 7}};
+        int[][] deepCopy1 = DeepCopy.deepCopy(matrix1);
+        assertTrue(deepCopy1[0] != matrix1[0]);
+        assertTrue(deepCopy1[1] != matrix1[1]);
+        assertTrue(deepCopy1[2] != matrix1[2]);
+        assertTrue(deepCopy1[3] != matrix1[3]);
+
     }
 }

--- a/code/exercises/src/test/java/com/nbicocchi/exercises/arrays/MatchUpTest.java
+++ b/code/exercises/src/test/java/com/nbicocchi/exercises/arrays/MatchUpTest.java
@@ -10,5 +10,7 @@ class MatchUpTest {
         assertEquals(2, MatchUp.matchUp(new int[]{1, 2, 3}, new int[]{2, 3, 10}));
         assertEquals(3, MatchUp.matchUp(new int[]{1, 2, 3}, new int[]{2, 3, 5}));
         assertEquals(2, MatchUp.matchUp(new int[]{1, 2, 3}, new int[]{2, 3, 3}));
+        assertEquals(2, MatchUp.matchUp(new int[]{5, 7, 4, 9}, new int[]{2, 3, 3, 7}));
+        assertEquals(3, MatchUp.matchUp(new int[]{-8, 2, -6, 5, 1}, new int[]{-6, 5, -5, 3, 1}));
     }
 }


### PR DESCRIPTION
I have noticed that in DeepCopyTest there are missing tests with multidimensional arrays having rows of different lengths. I have also noticed that in MatchUpTest there are missing tests with arrays having elements with negative sign and where some elements of the first array are greater than the elements of the second array.